### PR TITLE
在支付结果通知类WxPayOrderNotifyResult中添加了checkResult方法

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayOrderNotifyResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayOrderNotifyResult.java
@@ -284,7 +284,25 @@ public class WxPayOrderNotifyResult extends BaseWxPayResult {
    */
   @XStreamAlias("version")
   private String version;
-
+  
+  /**
+   * 校验返回结果签名.
+   *
+   * @param wxPayService the wx pay service
+   * @param signType     签名类型
+   * @param checkSuccess 是否同时检查结果是否成功
+   * @throws WxPayException the wx pay exception
+   */
+  @Override
+  public void checkResult(WxPayService wxPayService, String signType, boolean checkSuccess) throws WxPayException {
+    //防止伪造成功通知
+    if ("SUCCESS".equals(getReturnCode()) && getSign() == null) {
+      throw new WxPayException("伪造的通知！");
+    }
+    
+    super.checkResult(wxPayService, signType, checkSuccess);
+  }
+  
   /**
    * From xml wx pay order notify result.
    *

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayOrderNotifyResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayOrderNotifyResult.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.github.binarywang.wxpay.bean.result.BaseWxPayResult;
 import com.github.binarywang.wxpay.converter.WxPayOrderNotifyResultConverter;
+import com.github.binarywang.wxpay.exception.WxPayException;
 import com.github.binarywang.wxpay.util.SignUtils;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamAlias;


### PR DESCRIPTION
该方法重写了基类中的同名方法。
return_code为SUCCESS时，如果sign为空，则该通知请求是非微信通知请求，因此抛出异常。
否则，调用基类同名方法。